### PR TITLE
Create contribute-to-gatherpress.md

### DIFF
--- a/pathways/contribute-to-gatherpress.md
+++ b/pathways/contribute-to-gatherpress.md
@@ -1,0 +1,43 @@
+# Contribute to GatherPress
+
+**Function:** Build
+**Type:** Team
+
+GatherPress is an open-source event and meetup plugin for WordPress. Join the team, start with testing and triage, work up to beginner-friendly fixes, and settle into a feature area as you find your footing.
+
+## Before you start
+
+Complete the [common setup](/handbook/contribution-pathways/before-you-begin/) first, then:
+
+- **Connect:** Join [#gatherpress](https://wordpress.slack.com/archives/C07NB4N0ESJ) and [request access](https://gatherpress.org/get-involved/) to the GatherPress GitHub and Slack
+- **Setup:** [Create a Playground](https://wordpress.github.io/wordpress-playground/) or set up a local test environment
+- **Read first:** [GatherPress README](https://github.com/GatherPress/gatherpress?tab=readme-ov-file#gatherpress) and [contributing guidelines](https://github.com/GatherPress/gatherpress/blob/develop/docs/contributing.md)
+
+## Steps
+
+1. **Get to know GatherPress:** Try creating events, RSVPing, and exploring different views in your test environment.
+2. **Join team calls** if possible, otherwise review the weekly notes in #gatherpress.
+3. **Find active work:** Go to the [GitHub Milestones tab](https://github.com/GatherPress/gatherpress/milestones) and look for the lowest numbered milestone with open issues — that's generally the one in progress. Click through to view open issues.
+4. **Pick up an issue:** If you see something you can solve, comment with what you'll do and a rough timeline. Work one issue at a time, test your work, and reference the issue in your pull request.
+5. **Or help by testing:** Find an open [bug](https://github.com/GatherPress/gatherpress/issues?q=is%3Aissue%20state%3Aopen%20label%3Abug) and try to reproduce it, or find an issue that already has a pull request, scroll to "Preview changes with Playground," try the PR in different PHP versions, and comment with your findings.
+
+## When you're done
+
+**Done looks like:**
+- [ ] Your PR addresses one specific issue and references it (e.g. "Fixes #123")
+- [ ] You've tested your changes in Playground or a local environment
+- [ ] Your PR follows the [contributing guidelines](https://github.com/GatherPress/gatherpress/blob/develop/docs/contributing.md)
+- [ ] Any comments you've added are detailed and constructive, and you're following so you can respond to replies.
+
+**Submit your work:**
+If you worked on an issue, open a pull request in the [GatherPress repository](https://github.com/GatherPress/gatherpress) and reference the issue number in your PR description. If you tested a PR or bug, leave your findings as a comment.
+
+**Get reviewed:**
+A GatherPress maintainer will review your PR. Check the PR for comments and requested changes. Reviews typically happen within a few days — if it's been a week, a polite ping in #gatherpress is fine.
+
+**Next step:**
+Pick up another issue from the current milestone, or settle into a feature area that interests you. As you build familiarity, you can start reviewing other contributors' PRs too.  Follow up on any responses in Github as well.
+
+## Help
+
+Stuck? Check the [getting help guide](/handbook/contribution-pathways/before-you-begin/#getting-help), then ask in [#gatherpress](https://wordpress.slack.com/archives/C07NB4N0ESJ).


### PR DESCRIPTION
Added a guide for contributing to GatherPress. If it's good we can link it from the index.  Will also see if I can get other eyes on it.

This is for 
https://github.com/WordPress/contributor-handbook/issues/27