### PR TITLE
Patches to Photos pathways

### DIFF
--- a/pathways/design/contribute-to-photos-as-moderator.md
+++ b/pathways/design/contribute-to-photos-as-moderator.md
@@ -1,7 +1,7 @@
 # Design — Contribute to Photos as Moderator
 
 Function: Design  
-Type: Project  
+Type: Team  
 Level: Intermediate
 
 You'll review community-submitted photos and approve or decline them based on quality and content guidelines. Moderators keep the WordPress Photo Directory a reliable resource for contributors worldwide.
@@ -16,30 +16,24 @@ Complete the common setup first, then:
 
 ## Steps
 
-1. Read the [Moderating Photos handbook page](https://make.wordpress.org/photos/handbook/moderating-photos/) and fill out the form to apply to join the moderation team.
-2. Wait for a confirmation email that you've been accepted as a moderator.
-3. Log in to the [WordPress Photo Directory](https://wordpress.org/photos/).
-4. Open the moderation queue and select a photo to review.
-5. Check the photo against the [content and quality guidelines](https://wordpress.org/photos/guidelines/).
-6. Approve or decline the photo based on your assessment.
-7. If declining, leave a clear reason so the contributor knows what to improve.
-8. Repeat regularly — the queue is ongoing.
+1. Read the [Moderating Photos handbook page](https://make.wordpress.org/photos/handbook/moderating-photos/) and fill out the form to apply to join the moderation team, then wait for a confirmation email.
+2. Log in to the [WordPress Photo Directory](https://wordpress.org/photos/), and open the moderation queue.
+3. Select a photo to review and verify it meets the [content and quality guidelines](https://wordpress.org/photos/guidelines/).
+4. Approve or decline based on your assessment. If you decline, leave a clear reason so the contributor knows what to improve.
+5. Whenever there are multiple photos to review, we recommend working in small batches and reviewing one photo at a time.
 
 ## Contribution checklist
 
-- Accessed the moderation queue
-- Reviewed at least one photo against the guidelines
-- Approved or declined with a documented reason where needed
+- Applied and been approved to join the moderation team
+- Completed your first moderation review
 
 ## What happens next
 
-Your moderation decisions take effect immediately. The Photos team leads keep an eye on the queue and can answer questions if you're unsure about a call. If you don't get a response in Slack within a few days, post again — the channel is active.
-
-A natural next step is to moderate regularly and build familiarity with edge cases in the guidelines.
+Your moderation decisions take effect immediately. Continue to moderate regularly and build familiarity with edge cases in the guidelines.
 
 ## Help
 
-Stuck? Check the [getting help guide](#) then ask in [#photos](https://wordpress.slack.com/archives/photos).
+Stuck? Check the [getting help guide](#) then ask in [#photos](https://wordpress.slack.com/archives/photos).  The Photos team leads keep an eye on the queue and can answer questions if you're unsure about a call. If you don't get a response in Slack within a few days, post again — the channel is active.
 
 **Further reading:**
 

--- a/pathways/design/contribute-to-photos-as-moderator.md
+++ b/pathways/design/contribute-to-photos-as-moderator.md
@@ -1,7 +1,7 @@
 # Design — Contribute to Photos as Moderator
 
-Function: Design
-Type: Project
+Function: Design  
+Type: Project  
 Level: Intermediate
 
 You'll review community-submitted photos and approve or decline them based on quality and content guidelines. Moderators keep the WordPress Photo Directory a reliable resource for contributors worldwide.

--- a/pathways/design/contribute-to-photos-as-moderator.md
+++ b/pathways/design/contribute-to-photos-as-moderator.md
@@ -10,7 +10,7 @@ You'll review community-submitted photos and approve or decline them based on qu
 
 Complete the common setup first, then:
 
-- **Complete:** [Design — Contribute to Photos](https://wordpress.org/handbook/contribution-pathways/design/contribute-to-photos/)
+- **Complete:** [Design — Contribute to Photos](https://wordpress.org/handbook/contribution-pathways/design/contribute-to-photos/) with at least 30 published photos
 - **Read:** [Moderating Photos](https://make.wordpress.org/photos/handbook/moderating-photos/)
 - **Connect:** Join [#photos](https://wordpress.slack.com/archives/photos) on Slack and introduce yourself
 

--- a/pathways/design/contribute-to-photos.md
+++ b/pathways/design/contribute-to-photos.md
@@ -10,30 +10,26 @@ Upload at least 5 CC0-licensed photos to the WordPress Photo Directory. Your pho
 
 Complete the [common setup](/handbook/contribution-pathways/before-you-begin/) first, then:
 
-- **Setup:** Any camera works — smartphone, mirrorless/DSLR, or tablet.
+- **Setup:** Browse the [WordPress Photo Directory](https://wordpress.org/photos/) to see what's already there and get a feel for quality and themes
 - **Read:** [WordPress Photo Guidelines](https://wordpress.org/photos/guidelines/)
 - **Connect:** Join [#photos](https://wordpress.slack.com/messages/photos) on Slack and introduce yourself
 
 ## Steps
 
-1. Choose a theme — campus life, architecture, nature, or your local surroundings — and plan to shoot at least 5 photos.
-2. Take photos that follow the [WordPress Photo Guidelines](https://wordpress.org/photos/guidelines/): sharp, well-lit, and free of logos, trademarks, and recognizable faces.
-3. Export each photo as a JPEG, at least 2000×2000 pixels and between 1–20 MB.
-4. Submit one photo at a time at [wordpress.org/photos/submit/](https://wordpress.org/photos/submit/). Add alt text in English describing what's in the image, then confirm the license and guidelines checklist. You can have up to 5 photos in the moderation queue at once.
-5. After submitting, wait for the moderation email. If a photo is approved, submit the next one. If it's declined, the email explains why — revise if possible and resubmit.
+1. Choose a theme: campus life, architecture, nature, or your local surroundings. Shoot at least 5 photos that follow the [WordPress Photo Guidelines](https://wordpress.org/photos/guidelines/). You don't need fancy equipment — a smartphone works fine.
+2. Submit one photo at a time at [wordpress.org/photos/submit/](https://wordpress.org/photos/submit/). Add alt text in English describing what's in the image, confirm the license as CC0, and check the guidelines checklist. You can have up to 5 photos in the moderation queue at once.
+3. Wait for the moderation email. When a photo is declined, you can revise based on the feedback and resubmit.
 
 ## Contribution checklist
 
-- At least 5 photos approved by moderators
-- Each photo has alt text in English and is licensed as CC0
-- Your photos appear in the [WordPress Photo Directory](https://wordpress.org/photos/author/YOUR-USERNAME/)
-- Your WordPress.org profile shows the Photo Contributor badge
+- Submitted photos include alt text in English and CC0 license confirmation
+- At least 5 photos approved
 
 ## What happens next
 
 Moderation emails come from photos@wordpress.org — check your spam folder if you don't see one. Reviews can take a few days. If you haven't heard back after a week, ask in [#photos](https://wordpress.slack.com/messages/photos) on Slack.
 
-Once 5 photos are approved, share your contribution in [#photos](https://wordpress.slack.com/messages/photos) and ask for feedback. If you'd like to keep going, you can continue submitting photos or explore other [Design pathways](/handbook/contribution-pathways/).
+Once 5 photos are approved, you're officially a Photos contributor and will receive a profile badge. When you reach 30 approved photos, consider [becoming a moderator](/handbook/pathways/design/contribute-to-photos-as-moderator/) to help review submissions from other contributors.
 
 ## Help
 
@@ -41,4 +37,4 @@ Stuck? Check the [getting help guide](/handbook/contribution-pathways/before-you
 
 **Further reading:**
 
-- [Report an upload error](https://meta.trac.wordpress.org/newticket?component=Photo%20Directory) — use this if your photo meets the guidelines but still won't upload
+- [Report an upload error](https://meta.trac.wordpress.org/newticket?component=Photo%20Directory) — use this if your photo meets the guidelines but won't upload


### PR DESCRIPTION
Streamline Photos pathways: simplified steps, clarify checklists, moved "need help" type content to the appropriate section, added moderator progression, fixed links, and added trailing spaces for line breaks where needed