### PR TITLE
Manifest/2026 04 10

### DIFF
--- a/bin/handbook-manifest.json
+++ b/bin/handbook-manifest.json
@@ -97,6 +97,20 @@
         "parent": "pathways",
         "order": 3
     },
+    "pathways-design-contribute-to-photos": {
+        "title": "Contribute to the WordPress Photo Directory",
+        "slug": "contribute-to-photos",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/design\/contribute-to-photos.md",
+        "parent": "design",
+        "order": 0
+    },
+    "pathways-design-contribute-to-photos-as-moderator": {
+        "title": "Join the Photos Moderation Team",
+        "slug": "contribute-to-photos-as-moderator",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/design\/contribute-to-photos-as-moderator.md",
+        "parent": "design",
+        "order": 1
+    },
     "pathways-test-review-themes": {
         "title": "Review Themes",
         "slug": "review-themes",
@@ -139,6 +153,13 @@
         "parent": "write",
         "order": 0
     },
+    "pathways-write-create-content-for-learn-wordpress": {
+        "title": "Create Content for Learn WordPress",
+        "slug": "create-content-for-learn-wordpress",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/write\/create-content-for-learn-wordpress.md",
+        "parent": "write",
+        "order": 5
+    },
     "pathways-translate": {
         "title": "Translate",
         "slug": "translate",
@@ -173,6 +194,27 @@
         "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/organize\/organize-a-student-club.md",
         "parent": "organize",
         "order": 1
+    },
+    "pathways-organize-volunteer-at-a-wordpress-event": {
+        "title": "Volunteer at a WordPress Event",
+        "slug": "volunteer-at-a-wordpress-event",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/organize\/volunteer-at-a-wordpress-event.md",
+        "parent": "organize",
+        "order": 2
+    },
+    "pathways-organize-triage-docs-issues": {
+        "title": "Label Documentation Issues",
+        "slug": "triage-docs-issues",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/organize\/triage-docs-issues.md",
+        "parent": "organize",
+        "order": 3
+    },
+    "pathways-organize-coordinate-documentation-issues": {
+        "title": "Become a GitHub Issues Coordinator",
+        "slug": "coordinate-documentation-issues",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/organize\/coordinate-documentation-issues.md",
+        "parent": "organize",
+        "order": 4
     },
     "pathways-promote": {
         "title": "Promote",

--- a/bin/handbook-manifest.json
+++ b/bin/handbook-manifest.json
@@ -41,34 +41,6 @@
         "parent": "build",
         "order": 0
     },
-    "pathways-test-test-for-accessibility": {
-        "title": "Test for Accessibility",
-        "slug": "test-for-accessibility",
-        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/test-for-accessibility.md",
-        "parent": "test",
-        "order": 1
-    },
-    "pathways-test-audit-gatherpress-documentation": {
-        "title": "Audit GatherPress Documentation",
-        "slug": "audit-gatherpress-documentation",
-        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/audit-gatherpress-documentation.md",
-        "parent": "test",
-        "order": 3
-    },
-    "pathways-test-review-a-pathway-guide": {
-        "title": "Review a Pathway Guide",
-        "slug": "review-a-pathway-guide",
-        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/review-a-pathway-guide.md",
-        "parent": "test",
-        "order": 0
-    },
-    "pathways-test-help-test-patches": {
-        "title": "Patch Testing",
-        "slug": "help-test-patches",
-        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/help-test-patches.md",
-        "parent": "test",
-        "order": 2
-    },
     "pathways-build-contribute-to-theme-check-plugin": {
         "title": "Contribute to Theme Check Plugin",
         "slug": "contribute-to-theme-check-plugin",
@@ -111,13 +83,6 @@
         "parent": "design",
         "order": 1
     },
-    "pathways-test-review-themes": {
-        "title": "Review Themes",
-        "slug": "review-themes",
-        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/review-themes.md",
-        "parent": "test",
-        "order": 0
-    },
     "pathways-write": {
         "title": "Write",
         "slug": "write",
@@ -158,7 +123,7 @@
         "slug": "create-content-for-learn-wordpress",
         "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/write\/create-content-for-learn-wordpress.md",
         "parent": "write",
-        "order": 5
+        "order": 4
     },
     "pathways-translate": {
         "title": "Translate",
@@ -173,6 +138,41 @@
         "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/index.md",
         "parent": "pathways",
         "order": 6
+    },
+    "pathways-test-test-for-accessibility": {
+        "title": "Test for Accessibility",
+        "slug": "test-for-accessibility",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/test-for-accessibility.md",
+        "parent": "test",
+        "order": 1
+    },
+    "pathways-test-audit-gatherpress-documentation": {
+        "title": "Audit GatherPress Documentation",
+        "slug": "audit-gatherpress-documentation",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/audit-gatherpress-documentation.md",
+        "parent": "test",
+        "order": 3
+    },
+    "pathways-test-review-a-pathway-guide": {
+        "title": "Review a Pathway Guide",
+        "slug": "review-a-pathway-guide",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/review-a-pathway-guide.md",
+        "parent": "test",
+        "order": 0
+    },
+    "pathways-test-help-test-patches": {
+        "title": "Patch Testing",
+        "slug": "help-test-patches",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/help-test-patches.md",
+        "parent": "test",
+        "order": 2
+    },
+    "pathways-test-review-themes": {
+        "title": "Review Themes",
+        "slug": "review-themes",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/review-themes.md",
+        "parent": "test",
+        "order": 4
     },
     "pathways-organize": {
         "title": "Organize",

--- a/pathways/design/contribute-to-photos-as-moderator.md
+++ b/pathways/design/contribute-to-photos-as-moderator.md
@@ -1,4 +1,4 @@
-# Contribute to Photos as Moderator
+# Join the Photos Moderation Team
 
 Function: Design  
 Type: Team  

--- a/pathways/design/contribute-to-photos-as-moderator.md
+++ b/pathways/design/contribute-to-photos-as-moderator.md
@@ -1,4 +1,4 @@
-# Design — Contribute to Photos as Moderator
+# Contribute to Photos as Moderator
 
 Function: Design  
 Type: Team  


### PR DESCRIPTION
Adding just Manifest items first, then we'll add to indexes:

Organize  - volunteer-at-a-wordpress-event - Volunteer at a WordPress Event
Design -  contribute-to-photos - Contribute to the WordPress Photo Directory
Design  - contribute-to-photos-as-moderator - Join the Photos Moderation Team
Write  - create-content-for-learn-wordpress - Create Content for Learn WordPress
Organize -  triage-docs-issues - Label Documentation Issues
Organize - coordinate-documentation-issues - Become a GitHub Issues Coordinator
