### PR TITLE
Update Slack channel references in documentation

### DIFF
--- a/bin/handbook-manifest.json
+++ b/bin/handbook-manifest.json
@@ -83,6 +83,13 @@
         "parent": "design",
         "order": 1
     },
+    "pathways-design-submit-block-patterns": {
+        "title": "Submit Block Patterns",
+        "slug": "submit-block-patterns",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/design\/submit-block-patterns.md",
+        "parent": "design",
+        "order": 2
+    },
     "pathways-write": {
         "title": "Write",
         "slug": "write",

--- a/pathways/design/index.md
+++ b/pathways/design/index.md
@@ -5,3 +5,4 @@ Pathways for contributing through visual design, themes, and creative work.
 - **[Project: Review Themes](/handbook/pathways/test/review-themes/)** – Help review themes submitted to the WordPress directory
 - **[Project: Contribute Photos](/handbook/pathways/design/contribute-to-photos/)** – Help build the [WordPress Photo Directory](https://wordpress.org/photos/) with CC0-licensed photos
 - **[Team: Help Moderate Photos](/handbook/pathways/design/contribute-to-photos-as-moderator/)** – Keep the WordPress Photo Directory reliable by approving community submissions
+- **[Project: Submit Block Patterns](/handbook/pathways/design/submit-block-patterns/)** – Design and contribute patterns to the WordPress Patterns Directory

--- a/pathways/design/submit-block-patterns.md
+++ b/pathways/design/submit-block-patterns.md
@@ -12,7 +12,7 @@ Complete the [common setup](/handbook/contribution-pathways/before-you-begin/) f
 
 - **Setup:** Use [WordPress Playground](https://wordpress.org/playground/) to test your patterns before you submit them
 - **Read:** [A quick guide for building WordPress patterns](https://wordpress.org/patterns/about/) and [Submit your block pattern to the directory](https://wordpress.org/documentation/article/submit-your-block-pattern-to-the-directory/)
-- **Connect:** Join [#themes](https://wordpress.slack.com/archives/C02RP4Y3K) and introduce yourself
+- **Connect:** Join [#patterns](https://wordpress.slack.com/archives/patterns) and introduce yourself
 
 ## Steps
 
@@ -35,13 +35,13 @@ Complete the [common setup](/handbook/contribution-pathways/before-you-begin/) f
 
 ## What happens next
 
-Your patterns will go to review. When each is approved and published, you'll receive an email.
+Allow a few days for the patterns to be reviewed, then you'll receive an email to let you know if they were approved.
 
 When you're ready, design and submit more patterns, explore new categories, or consider auditing other patterns in the [Block Pattern Directory](https://wordpress.org/patterns/).
 
 ## Help
 
-Stuck? Check the [getting help guide](/handbook/contribution-pathways/before-you-begin/#getting-help), then ask in [#themes](https://wordpress.slack.com/archives/C02RP4Y3K). Search the channel first to see if someone has already answered your question.
+Stuck? Check the [getting help guide](/handbook/contribution-pathways/before-you-begin/#getting-help), then ask in [#patterns](https://wordpress.slack.com/archives/patterns). Search the channel first to see if someone has already answered your question.
 
 **Further reading:**
 
@@ -50,4 +50,3 @@ Stuck? Check the [getting help guide](/handbook/contribution-pathways/before-you
 - [Introduction to Block editor](https://learn.wordpress.org/lesson/intro-to-the-site-editor/)
 - [Using Block Patterns](https://wordpress.tv/2023/09/18/using-block-patterns-4/)
 - [Intro to Block patterns](https://learn.wordpress.org/tutorial/intro-to-block-patterns/)
-- [My Patterns](https://wordpress.org/patterns/my-patterns/) — view your drafts, submitted patterns, and published work

--- a/pathways/index.md
+++ b/pathways/index.md
@@ -22,6 +22,7 @@ If you're an existing contributor and your team needs more help, feel free to [s
 - **[Project: Review Themes](/handbook/pathways/test/review-themes/)** – Help review themes submitted to the WordPress directory
 - **[Project: Contribute Photos](/handbook/pathways/design/contribute-to-photos/)** – Help build the [WordPress Photo Directory](https://wordpress.org/photos/) with CC0-licensed photos
 - **[Team: Help Moderate Photos](/handbook/pathways/design/contribute-to-photos-as-moderator/)** – Keep the WordPress Photo Directory reliable by approving community submissions
+- **[Project: Submit Block Patterns](/handbook/pathways/design/submit-block-patterns/)** – Design and contribute patterns to the WordPress Patterns Directory
 
 ## Write
 


### PR DESCRIPTION
The #patterns channel exists now, and the bug is fixed, so this is officially unblocked.