### PR TITLE
Manifest/2026 04 23

### DIFF
--- a/bin/handbook-manifest.json
+++ b/bin/handbook-manifest.json
@@ -41,26 +41,54 @@
         "parent": "pathways",
         "order": 3
     },
+    "pathways-design": {
+        "title": "Design",
+        "slug": "design",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/design\/index.md",
+        "parent": "pathways",
+        "order": 4
+    },
+    "pathways-write": {
+        "title": "Write",
+        "slug": "write",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/write\/index.md",
+        "parent": "pathways",
+        "order": 5
+    },
+    "pathways-test": {
+        "title": "Test",
+        "slug": "test",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/index.md",
+        "parent": "pathways",
+        "order": 6
+    },
+    "pathways-translate": {
+        "title": "Translate",
+        "slug": "translate",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/translate\/index.md",
+        "parent": "pathways",
+        "order": 7
+    },
+    "pathways-organize": {
+        "title": "Organize",
+        "slug": "organize",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/organize\/index.md",
+        "parent": "pathways",
+        "order": 8
+    },
+    "pathways-promote": {
+        "title": "Promote",
+        "slug": "promote",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/promote\/index.md",
+        "parent": "pathways",
+        "order": 9
+    },
     "pathways-build-contribute-to-gatherpress": {
         "title": "Contribute to GatherPress",
         "slug": "contribute-to-gatherpress",
         "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/build\/contribute-to-gatherpress.md",
         "parent": "build",
         "order": 0
-    },
-    "pathways-build-contribute-to-theme-check-plugin": {
-        "title": "Contribute to Theme Check Plugin",
-        "slug": "contribute-to-theme-check-plugin",
-        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/build\/contribute-to-theme-check-plugin.md",
-        "parent": "build",
-        "order": 3
-    },
-    "pathways-build-create-a-playground-blueprint-for-a-community-plugin-or-theme": {
-        "title": "Create a Playground Blueprint for a Community Plugin or Theme",
-        "slug": "create-a-playground-blueprint-for-a-community-plugin-or-theme",
-        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/build\/create-a-playground-blueprint-for-a-community-plugin-or-theme.md",
-        "parent": "build",
-        "order": 2
     },
     "pathways-build-create-a-playground-blueprint": {
         "title": "Create a Playground Blueprint",
@@ -69,12 +97,19 @@
         "parent": "build",
         "order": 1
     },
-    "pathways-design": {
-        "title": "Design",
-        "slug": "design",
-        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/design\/index.md",
-        "parent": "pathways",
-        "order": 4
+    "pathways-build-create-a-playground-blueprint-for-a-community-plugin-or-theme": {
+        "title": "Create a Playground Blueprint for a Community Plugin or Theme",
+        "slug": "create-a-playground-blueprint-for-a-community-plugin-or-theme",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/build\/create-a-playground-blueprint-for-a-community-plugin-or-theme.md",
+        "parent": "build",
+        "order": 2
+    },
+    "pathways-build-contribute-to-theme-check-plugin": {
+        "title": "Contribute to Theme Check Plugin",
+        "slug": "contribute-to-theme-check-plugin",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/build\/contribute-to-theme-check-plugin.md",
+        "parent": "build",
+        "order": 3
     },
     "pathways-design-contribute-to-photos": {
         "title": "Contribute to the WordPress Photo Directory",
@@ -97,33 +132,12 @@
         "parent": "design",
         "order": 2
     },
-    "pathways-write": {
-        "title": "Write",
-        "slug": "write",
-        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/write\/index.md",
-        "parent": "pathways",
-        "order": 5
-    },
-    "pathways-write-document-a-wordpress-release": {
-        "title": "Document a WordPress Release",
-        "slug": "document-a-wordpress-release",
-        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/write\/document-a-wordpress-release.md",
-        "parent": "write",
-        "order": 1
-    },
-    "pathways-write-file-a-documentation-issue": {
-        "title": "File a Documentation Issue",
-        "slug": "file-a-documentation-issue",
-        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/write\/file-a-documentation-issue.md",
-        "parent": "write",
+    "pathways-design-design-meetup-kit": {
+        "title": "",
+        "slug": "design-meetup-kit",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/design\/design-meetup-kit.md",
+        "parent": "design",
         "order": 3
-    },
-    "pathways-write-work-on-existing-issues": {
-        "title": "Work on Existing Documentation Issues",
-        "slug": "work-on-existing-issues",
-        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/write\/work-on-existing-issues.md",
-        "parent": "write",
-        "order": 2
     },
     "pathways-write-create-a-pathway-guide": {
         "title": "Create a Pathway Guide",
@@ -132,40 +146,33 @@
         "parent": "write",
         "order": 0
     },
+    "pathways-write-document-a-wordpress-release": {
+        "title": "Document a WordPress Release",
+        "slug": "document-a-wordpress-release",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/write\/document-a-wordpress-release.md",
+        "parent": "write",
+        "order": 1
+    },
+    "pathways-write-work-on-existing-issues": {
+        "title": "Work on Existing Documentation Issues",
+        "slug": "work-on-existing-issues",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/write\/work-on-existing-issues.md",
+        "parent": "write",
+        "order": 2
+    },
+    "pathways-write-file-a-documentation-issue": {
+        "title": "File a Documentation Issue",
+        "slug": "file-a-documentation-issue",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/write\/file-a-documentation-issue.md",
+        "parent": "write",
+        "order": 3
+    },
     "pathways-write-create-content-for-learn-wordpress": {
         "title": "Create Content for Learn WordPress",
         "slug": "create-content-for-learn-wordpress",
         "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/write\/create-content-for-learn-wordpress.md",
         "parent": "write",
         "order": 4
-    },
-    "pathways-translate": {
-        "title": "Translate",
-        "slug": "translate",
-        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/translate\/index.md",
-        "parent": "pathways",
-        "order": 7
-    },
-    "pathways-test": {
-        "title": "Test",
-        "slug": "test",
-        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/index.md",
-        "parent": "pathways",
-        "order": 6
-    },
-    "pathways-test-test-for-accessibility": {
-        "title": "Test for Accessibility",
-        "slug": "test-for-accessibility",
-        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/test-for-accessibility.md",
-        "parent": "test",
-        "order": 1
-    },
-    "pathways-test-audit-gatherpress-documentation": {
-        "title": "Audit GatherPress Documentation",
-        "slug": "audit-gatherpress-documentation",
-        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/audit-gatherpress-documentation.md",
-        "parent": "test",
-        "order": 3
     },
     "pathways-test-review-a-pathway-guide": {
         "title": "Review a Pathway Guide",
@@ -174,12 +181,26 @@
         "parent": "test",
         "order": 0
     },
+    "pathways-test-test-for-accessibility": {
+        "title": "Test for Accessibility",
+        "slug": "test-for-accessibility",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/test-for-accessibility.md",
+        "parent": "test",
+        "order": 1
+    },
     "pathways-test-help-test-patches": {
         "title": "Patch Testing",
         "slug": "help-test-patches",
         "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/help-test-patches.md",
         "parent": "test",
         "order": 2
+    },
+    "pathways-test-audit-gatherpress-documentation": {
+        "title": "Audit GatherPress Documentation",
+        "slug": "audit-gatherpress-documentation",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/audit-gatherpress-documentation.md",
+        "parent": "test",
+        "order": 3
     },
     "pathways-test-review-themes": {
         "title": "Review Themes",
@@ -195,12 +216,26 @@
         "parent": "test",
         "order": 5
     },
-    "pathways-organize": {
-        "title": "Organize",
-        "slug": "organize",
-        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/organize\/index.md",
-        "parent": "pathways",
-        "order": 8
+    "pathways-test-help-test-beta-releases": {
+        "title": "Test Beta Relases",
+        "slug": "help-test-beta-releases",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/help-test-beta-releases.md",
+        "parent": "test",
+        "order": 6
+    },
+    "pathways-test-test-gutenberg-pr-with-playground": {
+        "title": "Test a Gutenberg Pull Request with Playground",
+        "slug": "test-gutenberg-pr-with-playground",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/test-gutenberg-pr-with-playground.md",
+        "parent": "test",
+        "order": 7
+    },
+        "pathways-translate-translate-training-content": {
+        "title": "Translate Training Content",
+        "slug": "translate-training-content",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/translate\/translate-training-content.md",
+        "parent": "translate",
+        "order": 0
     },
     "pathways-organize-suggest-a-pathway": {
         "title": "Suggest a Pathway",
@@ -237,12 +272,12 @@
         "parent": "organize",
         "order": 4
     },
-    "pathways-promote": {
-        "title": "Promote",
-        "slug": "promote",
-        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/promote\/index.md",
-        "parent": "pathways",
-        "order": 9
+    "pathways-organize-triage-gutenberg-project": {
+        "title": "Triage Gutenberg issues",
+        "slug": "triage-gutenberg-project",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/organize\/triage-gutenberg-project.md",
+        "parent": "organize",
+        "order": 0
     },
     "pathways-promote-add-captions-to-wptv-videos": {
         "title": "Add Captions to WPTV Videos",
@@ -250,5 +285,12 @@
         "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/promote\/add-captions-to-wptv-videos.md",
         "parent": "promote",
         "order": 0
+    },
+    "pathways-promote-promote-a-local-wordpress-event": {
+        "title": "Promote a Local WordPress Event",
+        "slug": "promote-a-local-wordpress-event",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/promote\/promote-a-local-wordpress-event.md",
+        "parent": "promote",
+        "order": 1
     }
 }

--- a/pathways/design/design-meetup-kit.md
+++ b/pathways/design/design-meetup-kit.md
@@ -1,0 +1,51 @@
+# Design a Meetup/WordCamp Kit
+
+**Function:** Design  
+**Type:** Project  
+**Level:** Beginner
+
+Design a set of reusable assets in Figma — slide templates, graphics, signage, and other event materials — that anyone can use to put together a WordPress meetup or WordCamp. Your work gives organizers a polished starting point without needing design skills, and lets them easily swap in their own details.
+
+## Before you start
+
+Complete the [common setup](https://github.com/WordPress/contributor-handbook/blob/main/pathways/before-you-begin.md) first, then:
+
+- **Setup:** Create a free [Figma](https://www.figma.com/) account
+- **Read:** [WordPress style guide](https://make.wordpress.org/design/handbook/design-guide/)
+- **Connect:** Join [#community-events](https://wordpress.slack.com/messages/community-events) on Slack and introduce yourself
+
+## Steps
+
+1. Post in [#community-events](https://wordpress.slack.com/messages/community-events) to introduce yourself and share what assets you're planning to design (for example: slide deck template, event signage, social graphics, badge). Get a thumbs up before you start so you're not duplicating existing work.
+2. Create a new Figma file in your personal drafts. Use the [WordPress style guide](https://make.wordpress.org/design/handbook/design-guide/) for colors and typography. If you need to include the WordPress logo, use only the official W Mark or Simplified version in BaseGray or White — download them from the [WordPress graphics and logos page](https://wordpress.org/about/logos/). Do not alter the logo or use it as part of a new logo or branding.
+3. Design your assets as reusable templates — use placeholder text and images so organizers can easily swap in their own event name, location, date, and photos.
+4. Share an early draft in [#community-events](https://wordpress.slack.com/messages/community-events) for feedback before finalizing. Tag your message with the event type (meetup or WordCamp) and list what's included.
+5. Export your final assets as SVG or PNG and set your Figma file to public view so anyone can open and duplicate it. Share the Figma link and exported files in [#community-events](https://wordpress.slack.com/messages/community-events). Make sure your Figma file is set to public view so anyone can open and duplicate it — this makes it easier for the community team to list it in the [WordCamp organizer handbook](https://make.wordpress.org/community/handbook/wordcamp-organizer/first-steps/helpful-documents-and-templates/).
+
+## Contribution checklist
+
+- Assets follow the WordPress style guide for colors and typography
+- WordPress logo usage is limited to the official W Mark or Simplified version, unaltered
+- Templates use placeholder text and images so details can be swapped out
+- Figma file is set to public view and can be duplicated by anyone
+- Figma link and exported files shared in #community-events
+
+## What happens next
+
+The community team will review your kit in [#community-events](https://wordpress.slack.com/messages/community-events). If you don't hear back within a week, follow up in the channel or try [#community](https://wordpress.slack.com/messages/community).
+
+Once approved, your kit can be added to the [Design Assets section of the WordCamp organizer handbook](https://make.wordpress.org/community/handbook/wordcamp-organizer/first-steps/helpful-documents-and-templates/#design-assets) alongside existing resources like the WordCamp badge templates — making it available to every organizer running a meetup or WordCamp.
+
+From here you can expand the kit with more asset types, or explore other [Design pathways](https://github.com/WordPress/contributor-handbook/tree/main/pathways/design).
+
+## Help
+
+Stuck? Check the [getting help guide](/handbook/contribution-pathways/before-you-begin/#getting-help), then ask in [#community-events](https://wordpress.slack.com/messages/community-events) or [#community](https://wordpress.slack.com/messages/community) on Slack.
+
+**Further reading:**
+- [WordPress graphics and logos](https://wordpress.org/about/logos/) — official logo downloads and approved versions
+- [WordPress style guide](https://make.wordpress.org/design/handbook/design-guide/) — colors, typography, and brand foundations
+- [WordCamp organizer handbook: helpful documents and templates](https://make.wordpress.org/community/handbook/wordcamp-organizer/first-steps/helpful-documents-and-templates/) — where approved design assets are listed
+- [Tools: Figma](https://make.wordpress.org/design/handbook/get-involved/tools-figma/) — overview of how WordPress uses Figma
+- [Video Thumbnail Generator](https://make.wordpress.org/design/handbook/resources/figma-thumbnail-generator/) — example of a community Figma design resource
+- [Figma Help Center](https://help.figma.com/) — tutorials for getting started with Figma


### PR DESCRIPTION
Adding these to the manifest. Will update indexes once they're published properly:

[Guide] Translate Training Content	https://github.com/WordPress/contributor-handbook/issues/53
[Guide] Test a Gutenberg Pull Request	https://github.com/WordPress/contributor-handbook/issues/135
[Guide] Meetup/WordCamp Kit Builder	https://github.com/WordPress/contributor-handbook/issues/84
[Guide] Help triage the Gutenberg project	https://github.com/WordPress/contributor-handbook/issues/24
[Guide] Test Beta Releases	https://github.com/WordPress/contributor-handbook/issues/136