### PR TITLE
Index/2026 05 29

### DIFF
--- a/bin/handbook-manifest.json
+++ b/bin/handbook-manifest.json
@@ -286,19 +286,26 @@
         "parent": "organize",
         "order": 4
     },
+    "pathways-organize-pathways/organize/triage-theme-check-issues": {
+        "title": "Triage Theme Check Issues",
+        "slug": "pathways/organize/triage-theme-check-issues",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/organize\/pathways/organize/triage-theme-check-issues.md",
+        "parent": "organize",
+        "order": 5
+    },
     "pathways-organize-triage-gutenberg-project": {
         "title": "Triage Gutenberg issues",
         "slug": "triage-gutenberg-project",
         "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/organize\/triage-gutenberg-project.md",
         "parent": "organize",
-        "order": 5
+        "order": 6
     },
     "pathways-organize-volunteer-for-a-team-meeting": {
         "title": "Volunteer for a Team Meeting",
         "slug": "volunteer-for-a-team-meeting",
         "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/organize\/volunteer-for-a-team-meeting.md",
         "parent": "organize",
-        "order": 6
+        "order": 7
     },
     "pathways-promote-add-captions-to-wptv-videos": {
         "title": "Add Captions to WPTV Videos",

--- a/pathways/organize/index.md
+++ b/pathways/organize/index.md
@@ -6,6 +6,7 @@ Pathways for contributing through community building, events, and coordination
 - **[Project: Organize a Student Club](https://make.wordpress.org/handbook/pathways/organize/organize-a-student-club/)** – Help organize a WordPress Student Club at your school or university
 - **[Project: Volunteer at a WordPress Event](https://make.wordpress.org/handbook/pathways/organize/volunteer-at-a-wordpress-event/)** – Assist with event logistics, registration, and other support
 - **[Task: Label Documentation Issues](https://make.wordpress.org/handbook/pathways/organize/triage-docs-issues/)** - Organize documentation tasks by labeling GitHub issues
-- **[Project: Triage Gutenberg Issues](https://make.wordpress.org/handbook/pathways/organize/triage-gutenberg-project/)** - Review, label, and organize Gutenberg bug reports so the right people can act on them
+- **[Task: Triage Gutenberg Issues](https://make.wordpress.org/handbook/pathways/organize/triage-gutenberg-project/)** - Review, label, and organize Gutenberg bug reports so the right people can act on them
+- **[Task: Triage Theme Check Issues](https://make.wordpress.org/handbook/pathways/organize/triage-theme-check-issues/)** - Keep the Theme Check plugin healthy by triaging bugs and testing fixes
 - **[Team: Become a GitHub Issues Coordinator](https://make.wordpress.org/handbook/pathways/organize/coordinate-documentation-issues/)** - Lead coordination for documentation issues
 - **[Task: Volunteer for a Team Meeting](https://make.wordpress.org/handbook/pathways/organize/volunteer-for-a-team-meeting/)** - Facilitate a meeting or share notes with the team

--- a/pathways/organize/triage-gutenberg-project.md
+++ b/pathways/organize/triage-gutenberg-project.md
@@ -1,7 +1,7 @@
 # Triage Gutenberg issues
 
-**Function:** Organize
-**Type:** Project
+**Function:** Organize  
+**Type:** Task  
 **Level:** Beginner
 
 Triaging keeps the Gutenberg repository healthy. You review issues, check whether bugs still happen, add labels, and organize reports so the right people can act on them. You do not need to be a developer or designer.


### PR DESCRIPTION
Adds new Theme Check Triage to "organize" index and to handbook manifest. Also switches Gutenberg Triage from **Project** to **Task**