### PR TITLE
Fix help link in Meetup kit pathway

### DIFF
--- a/pathways/design/design-meetup-kit.md
+++ b/pathways/design/design-meetup-kit.md
@@ -40,7 +40,7 @@ From here you can expand the kit with more asset types, or explore other [Design
 
 ## Help
 
-Stuck? Check the [getting help guide](/handbook/contribution-pathways/before-you-begin/#getting-help), then ask in [#community-events](https://wordpress.slack.com/messages/community-events) or [#community](https://wordpress.slack.com/messages/community) on Slack.
+Stuck? Check the [getting help guide](/handbook/pathways/before-you-begin/#getting-help), then ask in [#community-events](https://wordpress.slack.com/messages/community-events) or [#community](https://wordpress.slack.com/messages/community) on Slack.
 
 **Further reading:**
 - [WordPress graphics and logos](https://wordpress.org/about/logos/) — official logo downloads and approved versions


### PR DESCRIPTION
## Summary

Updates the legacy getting help guide link in the “Design a Meetup/WordCamp Kit” pathway to use the canonical `/handbook/pathways/` URL structure.

Fixes #220.
Related to #183 and #156.

## Changes

- Updates the getting help guide link.