### PR TITLE
Fix Create a Pathway Guide links

### DIFF
--- a/pathways/write/create-a-pathway-guide.md
+++ b/pathways/write/create-a-pathway-guide.md
@@ -8,35 +8,35 @@ Turn a pathway idea into a finished guide. Pick up an issue from the project boa
 
 ## Before you start
 
-Complete the [common setup](/handbook/contribution-pathways/before-you-begin/) first, then:
+Complete the [common setup](/handbook/pathways/before-you-begin/) first, then:
 
 - **Setup:** Familiarize yourself with the [Contributor Handbook GitHub repository](https://github.com/WordPress/contributor-handbook) and the [pathway project board](https://github.com/orgs/WordPress/projects/282/views/1)
-- **Read:** Review [About Pathways](/handbook/contribution-pathways/about/)
+- **Read:** Review [About Pathways](/handbook/pathways/about/)
 - **Connect:** Join [#core-program](https://wordpress.slack.com/archives/core-program) and introduce yourself
 
 ## Steps
 
 1. **Pick up an issue** from Ready or New on the [project board](https://github.com/orgs/WordPress/projects/282/views/1), comment /assign to show that you're working on it, then research the topic using linked resources, handbooks, tutorials, [Learn WordPress](https://learn.wordpress.org/), [WordPress.tv](https://wordpress.tv/), and team Slack channels.
 2. **Draft the guide** using [PROMPT.md](https://github.com/WordPress/contributor-handbook/blob/main/pathways/PROMPT.md) and AI, or with [TEMPLATE.md](https://github.com/WordPress/contributor-handbook/blob/main/pathways/TEMPLATE.md) as your guide, then post your draft (with markdown) as a comment on the issue.
-4. **Walk the pathway using your draft** as a new contributor would. Ask teams for feedback, too, and refine the markdown you've shared based on what you learn.
-5. **Signal it's reviewed and ready** by commenting /done on the issue. If you're able, set its Projects > Status to Update Manifest. Then add an .md file to the correct directory and submit a pull request, or an admin can add one from your comment.
+3. **Walk the pathway using your draft** as a new contributor would. Ask teams for feedback, too, and refine the markdown you've shared based on what you learn.
+4. **Signal it's reviewed and ready** by commenting /done on the issue. If you're able, set its Projects > Status to Update Manifest. Then add an .md file to the correct directory and submit a pull request, or an admin can add one from your comment.
 
 ## Contribution checklist
 
 - All links work and are current
 - Your draft is scannable and fits the [TEMPLATE.md](https://github.com/WordPress/contributor-handbook/blob/main/pathways/TEMPLATE.md)
-- You've tested the pathway, requested feedback, and refined accordingly 
+- You've tested the pathway, requested feedback, and refined accordingly
 - You've submitted a PR referencing the issue, or shared the guide as markdown in a comment.
 
 ## What happens next
 
 Maintainers will review your PR for clarity, accuracy, and completeness. Once approved, the pathway will be merged and published to the handbook.
 
-When you're ready, pick up another pathway from the project board or help review someone else's draft. You can also [suggest new guides here](https://github.com/WordPress/contributor-handbook/issues/new/choose).
+When you're ready, pick up another pathway from the project board or help review someone else's draft. You can also [suggest new guides here](https://github.com/WordPress/contributor-handbook/issues/new?template=2-new-pathway.yml).
 
 ## Help
 
-Stuck? Check the [getting help guide](/handbook/contribution-pathways/before-you-begin/#getting-help), then ask in [#core-program](https://wordpress.slack.com/archives/core-program).
+Stuck? Check the [getting help guide](/handbook/pathways/before-you-begin/#getting-help), then ask in [#core-program](https://wordpress.slack.com/archives/core-program).
 
 **Further reading:**
 


### PR DESCRIPTION
## Summary
- update legacy Pathways links to the canonical `/handbook/pathways/` URLs
- link directly to the New Pathway issue template
- fix skipped step numbering in the guide

## Issue
Fixes #219
Related to #168

## Testing
- Verified the canonical Make WordPress links return 200
- Verified the direct GitHub issue template URL resolves
- Ran `git diff --check`