### PR TITLE
Add GatherPress documentation pathway

### DIFF
--- a/bin/handbook-manifest.json
+++ b/bin/handbook-manifest.json
@@ -202,6 +202,13 @@
         "parent": "write",
         "order": 7
     },
+    "pathways-write-write-or-update-gatherpress-documentation": {
+        "title": "Write or Update GatherPress Documentation",
+        "slug": "write-or-update-gatherpress-documentation",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/write\/write-or-update-gatherpress-documentation.md",
+        "parent": "write",
+        "order": 8
+    },
     "pathways-test-review-a-pathway-guide": {
         "title": "Review a Pathway Guide",
         "slug": "review-a-pathway-guide",

--- a/pathways/write/write-or-update-gatherpress-documentation.md
+++ b/pathways/write/write-or-update-gatherpress-documentation.md
@@ -1,0 +1,60 @@
+# Write or Update GatherPress Documentation
+
+GatherPress is an open-source event and meetup plugin for WordPress. You can help by improving user guides, developer documentation, or inline docs so organizers and contributors can understand how the plugin works.
+
+No coding experience is required for many documentation issues. You will need a GitHub account, basic Markdown familiarity, and a willingness to check the plugin or docs before writing. If an inline documentation issue involves code comments, ask for guidance before you start.
+
+- **Reference:** [GatherPress documentation issues](https://github.com/GatherPress/gatherpress/issues?q=is%3Aopen+label%3Adocumentation)
+- **Connect:** Join [#gatherpress](https://wordpress.slack.com/archives/gatherpress) on WordPress Slack and introduce yourself
+
+## Steps
+
+1. **Find a documentation issue.** Start with [GatherPress documentation issues](https://github.com/GatherPress/gatherpress/issues?q=is%3Aopen+label%3Adocumentation). You can also check [good first issues](https://github.com/GatherPress/gatherpress/issues?q=is%3Aopen+label%3A%22good+first+issue%22), but pick one only if it has a clear writing or documentation task.
+
+2. **Check where the docs live.** Compare the issue with the [GatherPress documentation site](https://gatherpress.org/documentation/), the [user docs](https://gatherpress.org/documentation/documentation-for-users/), the [developer docs](https://gatherpress.org/documentation/documentation-for-developers/), and the [GitHub docs folder](https://github.com/GatherPress/gatherpress/tree/develop/docs) so you know what needs to change.
+
+3. **Claim the issue.** Leave a short comment saying you would like to work on it. If the issue is unclear, ask what page or section should be updated before you start.
+
+4. **Write the update.** Fork the repository, create a branch from `develop`, and update the relevant Markdown file. Keep the change focused on the issue you claimed.
+
+5. **Open a pull request.** Reference the issue in your pull request, describe what you changed, and mention whether you checked the docs page, the plugin behavior, or both.
+
+6. **Respond to review.** Watch for maintainer feedback and make any requested edits.
+
+## Contribution checklist
+
+- Claimed one GatherPress documentation issue before starting
+- Checked the current docs page or GitHub docs file
+- Created a branch from the GatherPress `develop` branch
+- Submitted a focused pull request that references the issue
+- Responded to review feedback from the GatherPress team
+
+## What happens next
+
+A GatherPress maintainer will review your pull request. If you do not hear back after a week, ask politely in #gatherpress and include the pull request link.
+
+After your first docs pull request, you can pick another documentation issue, audit a larger section of the docs, or try a beginner-friendly code issue.
+
+## Help
+
+Stuck? Check the [getting help guide](https://make.wordpress.org/handbook/pathways/before-you-begin/#getting-help), then ask in [#gatherpress](https://wordpress.slack.com/archives/gatherpress).
+
+**Further reading:**
+- [GatherPress documentation](https://gatherpress.org/documentation/)
+- [User documentation](https://gatherpress.org/documentation/documentation-for-users/)
+- [Developer documentation](https://gatherpress.org/documentation/documentation-for-developers/)
+- [GitHub docs folder](https://github.com/GatherPress/gatherpress/tree/develop/docs)
+- [Contributor Guide](https://github.com/GatherPress/gatherpress/blob/develop/docs/contributing.md)
+- [Get Involved](https://gatherpress.org/get-involved/)
+
+<div class="wp-block-wporg-sidebar-container is-floating-sidebar" data-breakpoint="1300px">
+  <div class="pathway-info">
+    <div class="pathway-header">
+      <span class="dashicons dashicons-edit-page"></span> Write
+    </div>
+    <div class="pathway-dtails">
+      <p>Beginner-friendly task</p>
+      <p class="newbies">New here? <a href="https://make.wordpress.org/handbook/pathways/before-you-begin/">Get set up</a> with accounts, community basics, and info on badges. →</p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- Adds a new Write pathway for contributing to GatherPress documentation
- Guides contributors to current GatherPress documentation issues, user docs, developer docs, and the docs folder
- Adds the new pathway to the handbook manifest

## Issue
Fixes #65

## Checks
- Verified GatherPress uses `develop` as the active branch
- Verified relevant links return successfully
- Ran `git diff --check`
- Validated `bin/handbook-manifest.json`