### PR TITLE
Create translation guide for themes and plugins

### DIFF
--- a/pathways/translate/translate-themes-and-plugins.md
+++ b/pathways/translate/translate-themes-and-plugins.md
@@ -1,0 +1,49 @@
+# Translate Themes and Plugins
+
+Help make WordPress accessible to more users by translating themes and plugins into your language. You'll contribute translations for the interface text that users see.
+
+- **Reference:** [How to Translate](https://make.wordpress.org/polyglots/handbook/translating/how-to-translate/)
+- **Connect:** Join [#polyglots](https://wordpress.slack.com/archives/polyglots) on Slack and introduce yourself
+
+## Steps
+
+1. **Find your locale team.** Go to [translate.wordpress.org](https://translate.wordpress.org/) and click "Contribute Translation" for your language. Check if your team has a [Style Guide or Glossary](https://make.wordpress.org/polyglots/handbook/translating/glossaries-and-style-guides-per-locale/) to follow.
+
+2. **Choose a project to translate.** Browse the [Top 100 plugins](https://translate.wordpress.org/stats/plugins/) or [Top 100 themes](https://translate.wordpress.org/stats/themes/) for your locale. Pick one that's close to complete (70%+ translated) to ensure your work goes live.
+
+3. **Start translating strings.** Click the untranslated count to see strings needing translation. Double-click a string to open the editor, enter your translation, and click "Suggest new translation."
+
+4. **Request review.** After submitting translations, contact your locale team for review via [local Slack](https://make.wordpress.org/polyglots/handbook/translating/teams/local-slacks/) if available, or post a PTE request on [Make/Polyglots](https://make.wordpress.org/polyglots/) with your locale tag.
+
+5. **Continue contributing.** Once familiar with the process, translate more strings or help complete projects nearing the 90% threshold for release.
+
+## Contribution checklist
+
+- You've translated at least 20 strings
+- Your translations follow your locale's style guide
+- You've requested review from your locale team
+
+## What happens next
+
+A translation editor will review your suggestions. Approved translations go live once the project reaches 90% completion for new projects, or immediately for projects with existing language packs. Consider requesting PTE status for projects you regularly translate.
+
+## Help
+
+Stuck? Check the [getting help guide](https://make.wordpress.org/handbook/pathways/before-you-begin/#getting-help), then ask in [#polyglots](https://wordpress.slack.com/archives/polyglots).
+
+**Further reading:**
+- [GlotPress interface guide](https://make.wordpress.org/polyglots/handbook/tools/glotpress-translate-wordpress-org/)
+- [Translation Teams](https://make.wordpress.org/polyglots/teams/)
+- [General Expectations for Translators](https://make.wordpress.org/polyglots/handbook/translating/expectations/)
+
+<div class="wp-block-wporg-sidebar-container is-floating-sidebar" data-breakpoint="1300px">
+  <div class="pathway-info">
+    <div class="pathway-header">
+      <span class="dashicons dashicons-translation"></span> Translate
+    </div>
+    <div class="pathway-details">
+      <p>Beginner-friendly task</p>
+      <p class="newbies">New here? <a href="https://make.wordpress.org/handbook/pathways/before-you-begin/">Get set up</a> with accounts, community basics, and info on badges. →</p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Added a guide for translating WordPress themes and plugins, including steps, contribution checklist, and resources for help.