### PR TITLE
Update links in accessibility review guidelines

### DIFF
--- a/pathways/test/review-themes-for-accessibility-ready-tag.md
+++ b/pathways/test/review-themes-for-accessibility-ready-tag.md
@@ -3,7 +3,7 @@
 Review a WordPress theme against the accessibility-ready requirements and report what you find. Your review helps a theme earn the accessibility-ready tag, which tells users it works with keyboards, screen readers, and other assistive technology.
 
 - **Prerequisite:** [Test for Accessibility](https://make.wordpress.org/handbook/pathways/test/test-for-accessibility/) — covers the keyboard and screen reader testing you'll use here
-- **Reference:** [Accessibility-ready testing process](https://wpaccessibility.org/docs/testing/testing-themes/)
+- **Reference:** [Accessibility-ready testing process](https://wpaccessibility.org/docs/accessibility-ready/testing-themes/)
 - **Connect:** Join [#accessibility](https://wordpress.slack.com/archives/accessibility) on Slack and introduce yourself
 
 ## Steps
@@ -12,11 +12,11 @@ Review a WordPress theme against the accessibility-ready requirements and report
 
 2. **Claim it.** For a new theme, comment on its Trac ticket that you're reviewing it for accessibility. For a published theme, ask in [#accessibility](https://wordpress.slack.com/archives/accessibility) and the team will assign you one. This stops two people testing the same theme.
 
-3. **Set up a test site.** Launch the [accessibility-ready InstaWP template site](https://app.instawp.io/launch?s=wp-accessibility-ready-test-sites&d=v2), then install, activate, and configure the theme with the demo content. Playground does not work for these reviews. Full instructions are in [Getting set up to test](https://wpaccessibility.org/docs/testing/testing-themes/setup/).
+3. **Set up a test site.** Launch the [accessibility-ready InstaWP template site](https://app.instawp.io/launch?s=wp-accessibility-ready-test-sites&d=v2), then install, activate, and configure the theme with the demo content. Playground does not work for these reviews. Full instructions are in [Getting set up to test](https://wpaccessibility.org/docs/accessibility-ready/testing-themes/).
 
 4. **Copy the report template.** Make your own copy of the Google Sheet report from the [Theme Testing Reports folder](https://drive.google.com/drive/folders/1z3v3U02W1WFt38Kvzb4aaVVkqzUq9pnP?usp=sharing) and fill in the Summary tab before you start.
 
-5. **Test against the requirements.** Work through the [accessibility-ready guidelines](https://wpaccessibility.org/docs/topics/theme-guidelines/), which include a testing note for each one. Check the theme with your keyboard, a screen reader, and an automated scanner, recording each result in your report. The [keyboard](https://wpaccessibility.org/docs/testing/keyboard/) and [screen reader](https://wpaccessibility.org/docs/testing/screen-readers/) guides show how.
+5. **Test against the requirements.** Work through the [accessibility-ready guidelines](https://wpaccessibility.org/docs/accessibility-ready/theme-guidelines/), which include a testing note for each one. Check the theme with your keyboard, a screen reader, and an automated scanner, recording each result in your report. The [keyboard](https://wpaccessibility.org/docs/testing/keyboard/) and [screen reader](https://wpaccessibility.org/docs/testing/screen-readers/) guides show how.
 
 6. **Share your report.** Post your completed report on the theme's Trac ticket and tag the developer so they can address what you found.
 
@@ -38,9 +38,9 @@ Once you've finished a review, pick up another theme from the queue, or join an 
 Stuck? Check the [getting help guide](https://make.wordpress.org/handbook/pathways/before-you-begin/#getting-help), then ask in [#accessibility](https://wordpress.slack.com/archives/accessibility).
 
 **Further reading:**
-- [WP accessibility-ready guidelines](https://wpaccessibility.org/docs/topics/theme-guidelines/) — the full requirements, with testing notes for each
-- [Testing workflow tips](https://wpaccessibility.org/docs/testing/testing-themes/theme-testing-workflow/) — practical advice for working through a review
-- [Reporting sheet overview](https://wpaccessibility.org/docs/testing/testing-themes/reporting-sheet/) — how the report template is organized
+- [WP accessibility-ready guidelines](https://wpaccessibility.org/docs/accessibility-ready/theme-guidelines/) — the full requirements, with testing notes for each
+- [Testing workflow tips](https://wpaccessibility.org/docs/accessibility-ready/testing-themes/theme-testing-workflow) — practical advice for working through a review
+- [Reporting sheet overview](https://wpaccessibility.org/docs/accessibility-ready/testing-themes/reporting-sheet/) — how the report template is organized
 - [Theme developer handbook: Accessibility](https://make.wordpress.org/themes/handbook/review/accessibility/) — the same requirements from the theme review side
 
 <div class="wp-block-wporg-sidebar-container is-floating-sidebar" data-breakpoint="1300px">


### PR DESCRIPTION
After feedback from users at the contributor day of WCEU '26, all info about the accessibility-ready tag is now bundled below one main menu item "Accessibility-ready program" in the knowledge base. 

So the URLs have changed. This PR changes the URLs to the updated location.