### PR TITLE
Add pathway for reviewing documentation fixes

### DIFF
--- a/bin/handbook-manifest.json
+++ b/bin/handbook-manifest.json
@@ -279,6 +279,13 @@
         "parent": "test",
         "order": 8
     },
+    "pathways-test-review-documentation-fixes": {
+        "title": "Review Documentation Fixes",
+        "slug": "review-documentation-fixes",
+        "markdown_source": "https:\/\/github.com\/WordPress\/contributor-handbook\/blob\/main\/pathways\/test\/review-documentation-fixes.md",
+        "parent": "test",
+        "order": 9
+    },
         "pathways-translate-translate-training-content": {
         "title": "Translate Training Content",
         "slug": "translate-training-content",

--- a/pathways/test/review-documentation-fixes.md
+++ b/pathways/test/review-documentation-fixes.md
@@ -1,4 +1,4 @@
-# Review Documentation Issues
+# Review Documentation Fixes
 
 You'll review proposed documentation fixes for accuracy, style, and accessibility, then leave feedback on the issue. This takes the heavy lifting off team members and helps publish fixes faster.
 

--- a/pathways/write/work-on-existing-issues.md
+++ b/pathways/write/work-on-existing-issues.md
@@ -1,34 +1,34 @@
-# Review Documentation Issues
+# Fix Documentation Issues
 
-You'll review proposed documentation fixes for accuracy, style, and accessibility, then leave feedback on the issue. This takes the heavy lifting off team members and helps publish fixes faster.
+Take on documentation problems by creating fixes for reported issues. You'll update outdated content, fix errors, and improve documentation based on tracked issues.
 
-- **Reference:** [Documentation Team Handbook](https://make.wordpress.org/docs/handbook/documentation-team-handbook/) — standards for grammar, style, tone, linking, and screenshots
+- **Prerequisite:** Complete [Review Documentation Fixes](https://make.wordpress.org/handbook/pathways/test/review-documentation-fixes/) to ensure you're familiar with documentation standards
+- **Reference:** [Documentation Team Handbook](https://make.wordpress.org/docs/handbook/documentation-team-handbook/)
 - **Connect:** Join [#docs](https://wordpress.slack.com/archives/docs) on Slack and introduce yourself
 
 ## Steps
 
-1. **Set up your testing environment.** Open [WordPress Playground](https://playground.wordpress.net/) for testing changes.
+1. **Review the project scope.** Read the [Blocks articles overhaul overview](https://github.com/WordPress/Documentation-Issue-Tracker/issues/2126) to understand the current focus and standards.
 
-2. **Pick an issue to review** from these [ready-for-review issues](https://github.com/WordPress/Documentation-Issue-Tracker/issues?q=state%3Aopen%20label%3A%22%5BStatus%5D%20Review%22%20AND%20label%3A%22good%20first%20issue%22%20OR%20label%3A%22%5BStatus%5D%20Review%22%20label%3A%22WP%20Credits%22). Comment `/assign` to claim it as a reviewer. Multiple reviewers per issue are welcome.
+2. **Pick an issue from the backlog.** Browse the [Blocks project board](https://github.com/orgs/WordPress/projects/267/views/1) and choose an issue from the backlog column. Comment `/assign` to claim it.
 
-3. **Understand the problem.** Read the issue description, visit the live documentation page, and confirm the reported problem still exists.
+3. **Research the current state.** Open the documentation page that needs fixing. Compare it against [WordPress Playground](https://playground.wordpress.net/) to verify what's outdated or incorrect. If nothing needs to be changed, comment saying so and ask for a review.
 
-4. **Review the proposed fix** for accuracy, grammar, style, tone, links, screenshots, and accessibility against the standards in the Documentation Team Handbook. Check the pages linked in [Further Reading](https://make.wordpress.org/handbook/pathways/write/work-on-existing-issues/#help) below.
+4. **Propose your fix.** Draft needed changes as a comment on the issue, following all documentation team standards. Indicate which sections you're updating, and provide the replacement text, as well as images if needed.
 
-5. **Leave a summary comment** with what you checked, any problems found, and specific suggestions. Mention a team member (@zzap or @atachibana) when ready for a final check.
+5. **Request review.** Comment that your fix is ready for review and mention @zzap or @atachibana for review.
 
 ## Contribution checklist
 
-- Confirmed the reported problem still exists on the live page
-- Verified the proposed fix is accurate and solves the problem
-- Checked against the Documentation Team Handbook standards
-- Posted a summary comment and mentioned a team member for final check
+- Issue claimed with `/assign`
+- Verified the problem against current WordPress
+- Fix follows documentation standards
+- Submitted clear before/after or draft
+- Requested review
 
 ## What happens next
 
-A team member will review your feedback and either request changes or apply the fix and close the issue. If there's no response after 2–3 weeks, ping in #docs.
-
-When you're ready, pick up another issue or try [filing one](https://make.wordpress.org/handbook/pathways/write/file-a-documentation-issue/).
+A reviewer will check your fix and provide feedback. Once approved, a team member with edit access will apply your changes and close the issue. You can then pick another issue from the backlog.
 
 ## Help
 
@@ -40,16 +40,3 @@ Stuck? Check the [getting help guide](https://make.wordpress.org/handbook/pathwa
 - [Tone and Voice Guide](https://make.wordpress.org/docs/handbook/documentation-team-handbook/tone-and-voice-guide/)
 - [External Linking Policy](https://make.wordpress.org/docs/handbook/documentation-team-handbook/external-linking-policy/)
 - [Screenshot best practices](https://make.wordpress.org/docs/handbook/get-involved/onboarding-sessions/updating-and-creating-new-screenshots/)
-- [What is WordPress Playground?](https://wordpress.github.io/wordpress-playground/about) — learn more about using WordPress Playground
-
-<div class="wp-block-wporg-sidebar-container is-floating-sidebar" data-breakpoint="1300px">
-  <div class="pathway-info">
-    <div class="pathway-header">
-      <span class="dashicons dashicons-edit-page"></span> Write
-    </div>
-    <div class="pathway-details">
-      <p>Beginner-friendly task</p>
-      <p class="newbies">New here? <a href="https://make.wordpress.org/handbook/pathways/before-you-begin/">Get set up</a> with accounts, community basics, and info on badges. →</p>
-    </div>
-  </div>
-</div>

--- a/pathways/write/work-on-existing-issues.md
+++ b/pathways/write/work-on-existing-issues.md
@@ -28,7 +28,7 @@ Take on documentation problems by creating fixes for reported issues. You'll upd
 
 ## What happens next
 
-A reviewer will check your fix and provide feedback. Once approved, a team member with edit access will apply your changes and close the issue. You can then pick another issue from the backlog.
+A reviewer will check your fix and provide feedback, typically within about two weeks. Once approved, a team member with edit access will apply your changes and close the issue. You can continue working on other issues in the meantime.
 
 ## Help
 

--- a/pathways/write/work-on-existing-issues.md
+++ b/pathways/write/work-on-existing-issues.md
@@ -14,7 +14,7 @@ Take on documentation problems by creating fixes for reported issues. You'll upd
 
 3. **Research the current state.** Open the documentation page that needs fixing. Compare it against [WordPress Playground](https://playground.wordpress.net/) to verify what's outdated or incorrect. If nothing needs to be changed, comment saying so and ask for a review.
 
-4. **Propose your fix.** Draft needed changes as a comment on the issue, following all documentation team standards. Indicate which sections you're updating, and provide the replacement text, as well as images if needed.
+4. **Propose necessary changes.** Draft needed changes as a comment on the issue, following all documentation team standards. Indicate which sections you're updating, and provide the replacement text, as well as images if needed.
 
 5. **Request review.** Comment that your fix is ready for review and mention @zzap or @atachibana for review.
 


### PR DESCRIPTION
moving this to test; we need a separate "Fix documentation issues" under Write